### PR TITLE
chore(benchmark): migrate cronjob deprecated api to batch/v1beta1

### DIFF
--- a/benchmark/k8s copy 1.yaml
+++ b/benchmark/k8s copy 1.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello
@@ -176,7 +176,7 @@ spec:
               initialDelaySeconds: 5
               periodSeconds: 10
             imagePullPolicy: IfNotPresent
-            resources: 
+            resources:
               requests:
                 cpu: "500m"
                 memory: "50Mi"

--- a/benchmark/k8s copy 10.yaml
+++ b/benchmark/k8s copy 10.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 11.yaml
+++ b/benchmark/k8s copy 11.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 12.yaml
+++ b/benchmark/k8s copy 12.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 13.yaml
+++ b/benchmark/k8s copy 13.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 14.yaml
+++ b/benchmark/k8s copy 14.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 15.yaml
+++ b/benchmark/k8s copy 15.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 16.yaml
+++ b/benchmark/k8s copy 16.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 17.yaml
+++ b/benchmark/k8s copy 17.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 18.yaml
+++ b/benchmark/k8s copy 18.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 19.yaml
+++ b/benchmark/k8s copy 19.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 2.yaml
+++ b/benchmark/k8s copy 2.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 20.yaml
+++ b/benchmark/k8s copy 20.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 21.yaml
+++ b/benchmark/k8s copy 21.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 22.yaml
+++ b/benchmark/k8s copy 22.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 23.yaml
+++ b/benchmark/k8s copy 23.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 24.yaml
+++ b/benchmark/k8s copy 24.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 25.yaml
+++ b/benchmark/k8s copy 25.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 26.yaml
+++ b/benchmark/k8s copy 26.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 27.yaml
+++ b/benchmark/k8s copy 27.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 28.yaml
+++ b/benchmark/k8s copy 28.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 29.yaml
+++ b/benchmark/k8s copy 29.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 3.yaml
+++ b/benchmark/k8s copy 3.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 30.yaml
+++ b/benchmark/k8s copy 30.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 31.yaml
+++ b/benchmark/k8s copy 31.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 32.yaml
+++ b/benchmark/k8s copy 32.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 33.yaml
+++ b/benchmark/k8s copy 33.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 34.yaml
+++ b/benchmark/k8s copy 34.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 35.yaml
+++ b/benchmark/k8s copy 35.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 36.yaml
+++ b/benchmark/k8s copy 36.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 37.yaml
+++ b/benchmark/k8s copy 37.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 38.yaml
+++ b/benchmark/k8s copy 38.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 39.yaml
+++ b/benchmark/k8s copy 39.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 4.yaml
+++ b/benchmark/k8s copy 4.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 40.yaml
+++ b/benchmark/k8s copy 40.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 41.yaml
+++ b/benchmark/k8s copy 41.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 42.yaml
+++ b/benchmark/k8s copy 42.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 43.yaml
+++ b/benchmark/k8s copy 43.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 44.yaml
+++ b/benchmark/k8s copy 44.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 45.yaml
+++ b/benchmark/k8s copy 45.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 46.yaml
+++ b/benchmark/k8s copy 46.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 47.yaml
+++ b/benchmark/k8s copy 47.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 48.yaml
+++ b/benchmark/k8s copy 48.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 49.yaml
+++ b/benchmark/k8s copy 49.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 5.yaml
+++ b/benchmark/k8s copy 5.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 50.yaml
+++ b/benchmark/k8s copy 50.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 51.yaml
+++ b/benchmark/k8s copy 51.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 52.yaml
+++ b/benchmark/k8s copy 52.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 53.yaml
+++ b/benchmark/k8s copy 53.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 54.yaml
+++ b/benchmark/k8s copy 54.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 55.yaml
+++ b/benchmark/k8s copy 55.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 56.yaml
+++ b/benchmark/k8s copy 56.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 57.yaml
+++ b/benchmark/k8s copy 57.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 58.yaml
+++ b/benchmark/k8s copy 58.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 59.yaml
+++ b/benchmark/k8s copy 59.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 6.yaml
+++ b/benchmark/k8s copy 6.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 60.yaml
+++ b/benchmark/k8s copy 60.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 61.yaml
+++ b/benchmark/k8s copy 61.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 62.yaml
+++ b/benchmark/k8s copy 62.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 63.yaml
+++ b/benchmark/k8s copy 63.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 64.yaml
+++ b/benchmark/k8s copy 64.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 65.yaml
+++ b/benchmark/k8s copy 65.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 66.yaml
+++ b/benchmark/k8s copy 66.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 67.yaml
+++ b/benchmark/k8s copy 67.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 68.yaml
+++ b/benchmark/k8s copy 68.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 69.yaml
+++ b/benchmark/k8s copy 69.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 7.yaml
+++ b/benchmark/k8s copy 7.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 70.yaml
+++ b/benchmark/k8s copy 70.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 71.yaml
+++ b/benchmark/k8s copy 71.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 72.yaml
+++ b/benchmark/k8s copy 72.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 73.yaml
+++ b/benchmark/k8s copy 73.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 74.yaml
+++ b/benchmark/k8s copy 74.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 75.yaml
+++ b/benchmark/k8s copy 75.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 76.yaml
+++ b/benchmark/k8s copy 76.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 77.yaml
+++ b/benchmark/k8s copy 77.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 78.yaml
+++ b/benchmark/k8s copy 78.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 79.yaml
+++ b/benchmark/k8s copy 79.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 8.yaml
+++ b/benchmark/k8s copy 8.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 80.yaml
+++ b/benchmark/k8s copy 80.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 81.yaml
+++ b/benchmark/k8s copy 81.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 82.yaml
+++ b/benchmark/k8s copy 82.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 83.yaml
+++ b/benchmark/k8s copy 83.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 84.yaml
+++ b/benchmark/k8s copy 84.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 85.yaml
+++ b/benchmark/k8s copy 85.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 86.yaml
+++ b/benchmark/k8s copy 86.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 87.yaml
+++ b/benchmark/k8s copy 87.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 88.yaml
+++ b/benchmark/k8s copy 88.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 89.yaml
+++ b/benchmark/k8s copy 89.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 9.yaml
+++ b/benchmark/k8s copy 9.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 90.yaml
+++ b/benchmark/k8s copy 90.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 91.yaml
+++ b/benchmark/k8s copy 91.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 92.yaml
+++ b/benchmark/k8s copy 92.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 93.yaml
+++ b/benchmark/k8s copy 93.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 94.yaml
+++ b/benchmark/k8s copy 94.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 95.yaml
+++ b/benchmark/k8s copy 95.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 96.yaml
+++ b/benchmark/k8s copy 96.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 97.yaml
+++ b/benchmark/k8s copy 97.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 98.yaml
+++ b/benchmark/k8s copy 98.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s copy 99.yaml
+++ b/benchmark/k8s copy 99.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello

--- a/benchmark/k8s.yaml
+++ b/benchmark/k8s.yaml
@@ -140,7 +140,7 @@ spec:
       port: 80
       targetPort: 9376
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: hello


### PR DESCRIPTION
 The `batch/v1beta1` API version of CronJob [has been removed in `v1.25`](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#cronjob-v125).